### PR TITLE
Feature/cover scanner

### DIFF
--- a/MangaManager/src/Common/loadedcomicinfo.py
+++ b/MangaManager/src/Common/loadedcomicinfo.py
@@ -75,28 +75,24 @@ class LoadedComicInfo:
     changed_tags = []
 
     _cover_action: CoverActions | None = None
+    # Path to the new cover selected by the user
     _new_cover_path: str | None = None
     new_cover_cache: ImageTk.PhotoImage | None = None
-
+    # Path to the new backcover selected by the user
     _backcover_action: CoverActions | None = None
     _new_backcover_path: str | None = None
     new_backcover_cache: ImageTk.PhotoImage | None = None
 
-    def get_cover_cache(self) -> ImageTk.PhotoImage | None:
+    def get_cover_cache(self, is_backcover=False) -> ImageTk.PhotoImage | None:
         if self._cover_action is None:
-            return self.cover_cache
+            return self.backcover_cache if is_backcover else self.cover_cache
         else:
-            return self.new_cover_cache
-
-    def get_backcover_cache(self) -> ImageTk.PhotoImage | None:
-        if self._backcover_action is None:
-            return self.backcover_cache
-        else:
-            return self.new_backcover_cache
+            return self.new_backcover_cache if is_backcover else self.new_cover_cache
 
     @property
     def cover_action(self):
         return self._cover_action
+
     @cover_action.setter
     def cover_action(self, value: CoverActions):
         if value == CoverActions.RESET:
@@ -106,9 +102,11 @@ class LoadedComicInfo:
         else:
             self._cover_action = value
             self.has_changes = True
+
     @property
     def backcover_action(self):
         return self._backcover_action
+
     @backcover_action.setter
     def backcover_action(self, value: CoverActions):
         if value == CoverActions.RESET:
@@ -118,7 +116,6 @@ class LoadedComicInfo:
         else:
             self._backcover_action = value
             self.has_changes = True
-
 
     @property
     def new_cover_path(self):

--- a/MangaManager/src/Common/loadedcomicinfo.py
+++ b/MangaManager/src/Common/loadedcomicinfo.py
@@ -82,6 +82,18 @@ class LoadedComicInfo:
     _new_backcover_path: str | None = None
     new_backcover_cache: ImageTk.PhotoImage | None = None
 
+    def get_cover_cache(self) -> ImageTk.PhotoImage | None:
+        if self._cover_action is None:
+            return self.cover_cache
+        else:
+            return self.new_cover_cache
+
+    def get_backcover_cache(self) -> ImageTk.PhotoImage | None:
+        if self._backcover_action is None:
+            return self.backcover_cache
+        else:
+            return self.new_backcover_cache
+
     @property
     def cover_action(self):
         return self._cover_action

--- a/MangaManager/src/MetadataManager/CoverManager/CoverManager.py
+++ b/MangaManager/src/MetadataManager/CoverManager/CoverManager.py
@@ -10,7 +10,7 @@ from tkinter.filedialog import askopenfile
 from tkinter.ttk import Treeview
 
 import numpy as np
-from PIL import Image, ImageTk, ImageChops
+from PIL import Image, ImageTk
 from pkg_resources import resource_filename
 
 from src.Common.loadedcomicinfo import LoadedComicInfo, CoverActions
@@ -21,38 +21,11 @@ from src.MetadataManager.MetadataManagerGUI import GUIApp
 from src.Settings.SettingHeading import SettingHeading
 from src.Settings.Settings import Settings
 
-action_template = abspath(resource_filename(__name__, '../../../res/cover_action_template.png'))  # TODO: Use resource factory
+action_template = abspath(
+    resource_filename(__name__, '../../../res/cover_action_template.png'))  # TODO: Use resource factory
 
 logger = logging.getLogger()
 overlay_image: Image = None
-
-
-def compare_image(img1: Image, imge2: Image, x, y, delta):
-    """
-    Compares the image histograms
-    :param img1: Image Object
-    :param imge2: Image Object
-    :param x: image histogram
-    :param y: image histogram
-    :param delta: 1-100 match value
-    :return:
-    """
-    # Todo: remove img1 and img2. Not doing much apparently
-    actual_error = 0
-    if len(x) == len(y):
-        error = np.sqrt(((x - y) ** 2).mean())
-        error = str(error)[:2]
-        actual_error = float(100) - float(error)
-    diff = ImageChops.difference(img1, imge2).getbbox()
-    if diff:
-        print("Not Duplicate Image")
-    else:
-        print(f"Percentage: {actual_error}")
-        if actual_error >= delta:
-            print("Same image")
-            return True
-        else:
-            print("images not similar:")
 
 
 class ComicFrame(CoverFrame):
@@ -67,7 +40,8 @@ class ComicFrame(CoverFrame):
 
         self.loaded_cinfo: LoadedComicInfo = loaded_cinfo
         self.configure(highlightthickness=2, highlightcolor="grey", highlightbackground="grey", padx=20, pady=10)
-        title = tkinter.Label(self, text=f"{loaded_cinfo.file_name[:70]}{'...' if len(loaded_cinfo.file_name) > 70 else ''}")
+        title = tkinter.Label(self,
+                              text=f"{loaded_cinfo.file_name[:70]}{'...' if len(loaded_cinfo.file_name) > 70 else ''}")
         Hovertip(title, loaded_cinfo.file_name, 20)
         title.pack(expand=True)
         # COVER
@@ -108,7 +82,7 @@ class ComicFrame(CoverFrame):
         btn = Button(btn_frame, text="Reset", command=lambda:
         self.cover_action(self.loaded_cinfo, action=CoverActions.RESET))
         btn.pack(side="left", fill="x", expand=True)
-        self.cover_action(self.loaded_cinfo, auto_trigger=True,proc_update=False)
+        self.cover_action(self.loaded_cinfo, auto_trigger=True, proc_update=False)
 
         # BACK COVER
         self.backcover_frame = Frame(self)
@@ -152,7 +126,7 @@ class ComicFrame(CoverFrame):
         btn.pack(side="left", fill="x", expand=True)
 
         # Load backcover
-        self.backcover_action(self.loaded_cinfo, auto_trigger=True,proc_update=False)
+        self.backcover_action(self.loaded_cinfo, auto_trigger=True, proc_update=False)
 
 
 class CoverManager(tkinter.Toplevel):
@@ -166,9 +140,10 @@ class CoverManager(tkinter.Toplevel):
         Initializes the toplevel window but hides the window.
         """
         if self.name is None:  # Check if the "name" attribute has been set
-            raise ValueError(f"Error initializing the {self.__class__.__name__} Extension. The 'name' attribute must be set in the ExtensionApp class.")
+            raise ValueError(
+                f"Error initializing the {self.__class__.__name__} Extension. The 'name' attribute must be set in the ExtensionApp class.")
         # if self.embedded_ui:
-        super().__init__(master=master,**kwargs)
+        super().__init__(master=master, **kwargs)
         self.title(self.__class__.name)
         if super_ is not None:
             self._super = super_
@@ -210,11 +185,12 @@ class CoverManager(tkinter.Toplevel):
         num_widgets = width // 414
         try:
             logger.trace(f"Number of widgets per row: {num_widgets}")
-            logger.trace(f"Number of rows: {len(self.scrolled_widget.winfo_children())/num_widgets}")
+            logger.trace(f"Number of rows: {len(self.scrolled_widget.winfo_children()) / num_widgets}")
         except ZeroDivisionError:
             pass
         # redraw the widgets
-        widgets_to_redraw = list(reversed(copy.copy(self.scrolled_widget.winfo_children())))  # self.scrolled_widget.grid_slaves()
+        widgets_to_redraw = list(
+            reversed(copy.copy(self.scrolled_widget.winfo_children())))  # self.scrolled_widget.grid_slaves()
         i = 0
         j = 0
         while widgets_to_redraw:
@@ -246,37 +222,37 @@ class CoverManager(tkinter.Toplevel):
         tree.heading("#1", text="Filename")
         tree.column("#2", anchor=CENTER, width=80)
         tree.heading("#2", text="Type")
-        tree.pack(expand=True, fill="y", pady=(80,0), padx=30, side="top")
+        tree.pack(expand=True, fill="y", pady=(80, 0), padx=30, side="top")
         action_buttons = Frame(side_panel_control)
-        action_buttons.pack(ipadx=20,ipady=20,pady=(0,80), fill="x", padx=30)
+        action_buttons.pack(ipadx=20, ipady=20, pady=(0, 80), fill="x", padx=30)
 
         ButtonWidget(master=action_buttons, text="Delete Selected",
                      tooltip="Deletes the image for the selected cover/backcovers",
-                     command=lambda: self.run_bulk_action(CoverActions.DELETE)).pack(side="top", fill="x",ipady=10)
+                     command=lambda: self.run_bulk_action(CoverActions.DELETE)).pack(side="top", fill="x", ipady=10)
         ButtonWidget(master=action_buttons, text="Append to Selected",
                      tooltip="Appends the image for the selected cover/backcovers",
-                     command=lambda: self.run_bulk_action(CoverActions.APPEND)).pack( side="top", fill="x",ipady=10)
+                     command=lambda: self.run_bulk_action(CoverActions.APPEND)).pack(side="top", fill="x", ipady=10)
         ButtonWidget(master=action_buttons, text="Replace Selected",
                      tooltip="Replaces the image for the selected cover/backcovers",
-                     command=lambda: self.run_bulk_action(CoverActions.REPLACE)).pack(side="top", fill="x",ipady=10)
+                     command=lambda: self.run_bulk_action(CoverActions.REPLACE)).pack(side="top", fill="x", ipady=10)
         ButtonWidget(master=action_buttons, text="Clear Selection",
-                     command=self.clear_selection).pack(fill="x",ipady=10)
+                     command=self.clear_selection).pack(fill="x", ipady=10)
         ButtonWidget(master=action_buttons, text="Close window",
-                     command=self.exit_btn).pack(fill="x",ipady=10)
+                     command=self.exit_btn).pack(fill="x", ipady=10)
 
-        self.select_similar_btn = ButtonWidget(master=action_buttons, text="Select similar",state="disabled",
-                     command=self.select_similar)
+        self.select_similar_btn = ButtonWidget(master=action_buttons, text="Select similar", state="disabled",
+                                               command=self.select_similar)
         self.select_similar_btn.pack(fill="x", ipady=10)
 
         frame = Frame(action_buttons)
-        frame.pack(fill="x",pady=(10,0))
-        tkinter.Label(frame,text="Delta %").pack(side="left")
+        frame.pack(fill="x", pady=(10, 0))
+        tkinter.Label(frame, text="Delta %").pack(side="left")
         self.delta_entry = tkinter.Entry(frame, width="10")
-        self.delta_entry.insert(0,"90")
+        self.delta_entry.insert(0, "90")
         self.delta_entry.pack(side="left")
 
         frame = tkinter.LabelFrame(action_buttons, text="Scan:")
-        frame.pack(fill="x",expand=True,pady=(0,5))
+        frame.pack(fill="x", expand=True, pady=(0, 5))
         self.scan_covers = tkinter.BooleanVar(value=True)
         self.scan_backcovers = tkinter.BooleanVar(value=False)
 
@@ -298,7 +274,8 @@ class CoverManager(tkinter.Toplevel):
         # so that it will be called whenever the window is resized
 
         if not self._super.loaded_cinfo_list:
-            mb.showwarning("No files selected", "No files were selected so none will be displayed in cover manager", parent=self)
+            mb.showwarning("No files selected", "No files were selected so none will be displayed in cover manager",
+                           parent=self)
             # self.deiconify()
             self.destroy()
             return
@@ -315,54 +292,7 @@ class CoverManager(tkinter.Toplevel):
             comic_frame.grid()
         self.redraw(None)
 
-    def _compare_images(self, selected_image, x, compared_image, comicframe, pos):
-        delta = float(self.delta_entry.get())
-        y = np.array(compared_image.histogram())
-        if compare_image(selected_image, compared_image, x, y, delta=delta):
-            self.select_frame(None, frame=comicframe, pos=pos)
-
-    def select_similar(self):
-        """
-        Compares the selected file with all the loaded covers and backcovers
-        Selects files that match.
-        :return:
-        """
-        assert len(self.selected_frames) == 1
-        frame, pos = self.selected_frames[0]
-        if pos == "front":
-            selected_photoimage: ImageTk.PhotoImage = frame.loaded_cinfo.get_cover_cache()
-        else:
-            selected_photoimage: ImageTk.PhotoImage = frame.loaded_cinfo.get_backcover_cache()
-
-        selected_image = ImageTk.getimage(selected_photoimage)
-        x = np.array(selected_image.histogram())
-        self.clear_selection()
-        # Compare all covers:
-        for comicframe in self.scrolled_widget.winfo_children():
-            try:
-                comicframe: ComicFrame
-                lcinfo: LoadedComicInfo = comicframe.loaded_cinfo
-                if self.scan_covers.get():
-                    image = lcinfo.get_cover_cache()
-                    if image is None:
-                        logger.error(f"Failed to compare cover image. File is not loaded. File '{lcinfo.file_name}'")
-                    else:
-                        compared_image = ImageTk.getimage(image)
-                        print("Comparing front")
-                        self._compare_images(selected_image, x, compared_image, comicframe, "front")
-                if self.scan_backcovers.get():
-                    image = lcinfo.get_backcover_cache()
-                    if image is None:
-                        logger.error(f"Failed to compare backcover image. File is not loaded. File '{lcinfo.file_name}'")
-                    else:
-                        compared_image = ImageTk.getimage(image)
-                        print("Comparing back")
-                        self._compare_images(selected_image, x, compared_image, comicframe, "back")
-
-            except Exception:
-                logger.exception(f"Failed to compare images for file {comicframe.loaded_cinfo.file_name}")
-
-    def select_frame(self, _, frame: ComicFrame, pos:str):
+    def select_frame(self, _, frame: ComicFrame, pos: str):
         """
         Selects the frame. Adds to selected frames and modifies its border to show green as "selected"
         """
@@ -373,7 +303,6 @@ class CoverManager(tkinter.Toplevel):
                     self.tree.delete(children)
                     del self.tree_dict[children]
             if pos == "front":
-
                 frame.cover_canvas.configure(highlightbackground="#f0f0f0", highlightcolor="white")
             else:
                 frame.backcover_canvas.configure(highlightbackground="#f0f0f0", highlightcolor="white")
@@ -387,7 +316,7 @@ class CoverManager(tkinter.Toplevel):
             else:
                 frame.backcover_canvas.configure(highlightbackground="green", highlightcolor="green")
         # noinspection PyTypeChecker
-        self.select_similar_btn.configure(state="normal" if len(self.selected_frames)==1 else "disabled")
+        self.select_similar_btn.configure(state="normal" if len(self.selected_frames) == 1 else "disabled")
 
     def run_bulk_action(self, action: CoverActions):
         """
@@ -398,7 +327,8 @@ class CoverManager(tkinter.Toplevel):
         new_cover_file = None
         cover = None
         if action == CoverActions.APPEND or action == CoverActions.REPLACE:
-            new_cover_file = askopenfile(parent=self,initialdir=Settings().get(SettingHeading.Main, 'covers_folder_path')).name
+            new_cover_file = askopenfile(parent=self,
+                                         initialdir=Settings().get(SettingHeading.Main, 'covers_folder_path')).name
 
         for frame, type_ in self.selected_frames:
             # create a ComicFrame for each LoadedComicInfo object
@@ -456,3 +386,79 @@ class CoverManager(tkinter.Toplevel):
         for children in self.tree.get_children():
             self.tree.delete(children)
             del self.tree_dict[children]
+
+    ########################
+    # Cover scanner methods
+    ########################
+    def select_similar(self):
+        """
+        Compares the selected file with all the loaded covers and backcovers
+        Selects files that match.
+        :return:
+        """
+        assert len(self.selected_frames) == 1
+        frame, pos = self.selected_frames[0]
+        if pos == "front":
+            selected_photoimage: ImageTk.PhotoImage = frame.loaded_cinfo.get_cover_cache()
+        else:
+            selected_photoimage: ImageTk.PhotoImage = frame.loaded_cinfo.get_cover_cache(True)
+
+        selected_image = ImageTk.getimage(selected_photoimage)
+        x = np.array(selected_image.histogram())
+        self.clear_selection()
+        # Compare all covers:
+        for comicframe in self.scrolled_widget.winfo_children():
+            comicframe: ComicFrame
+            lcinfo: LoadedComicInfo = comicframe.loaded_cinfo
+            try:
+                if self.scan_covers.get():
+                    self._scan_images(x, lcinfo, is_backcover=False, comicframe=comicframe)
+                if self.scan_backcovers.get():
+                    self._scan_images(x, lcinfo, is_backcover=True, comicframe=comicframe)
+            except Exception:
+                logger.exception(f"Failed to compare images for file {comicframe.loaded_cinfo.file_name}")
+
+    def _scan_images(self, x, lcinfo, comicframe, is_backcover=False):
+        """
+
+        :param x: Numpy array containing the selected image histogram
+        :param lcinfo: The loaded comicinfo of the compared image
+        :param is_backcover:
+        :param comicframe: The comicframe the lcinfo is linked to
+        :return:
+        """
+        image = lcinfo.cover_cache(is_backcover)
+        if image is None:
+            logger.error(f"Failed to compare cover image. File is not loaded. File '{lcinfo.file_name}'")
+        else:
+            compared_image = ImageTk.getimage(image)
+            self._compare_images(x, compared_image, comicframe, "back" if is_backcover else "front")
+
+    def _compare_images(self, x, compared_image, comicframe, pos):
+        delta = float(self.delta_entry.get())
+        y = np.array(compared_image.histogram())
+        if self.compare_image(x, y, delta=delta):
+            self.select_frame(None, frame=comicframe, pos=pos)
+
+    @staticmethod
+    def compare_image(x, y, delta:float):
+        """
+        Compares the image histograms
+        :param img1: Image Object
+        :param imge2: Image Object
+        :param x: Numpy array containing the selected image histogram
+        :param y: Numpy array containing the selected image histogram
+        :param delta: 1-100 match value
+        :return:
+        """
+        actual_error = 0
+        if len(x) == len(y):
+            error = np.sqrt(((x - y) ** 2).mean())
+            error = str(error)[:2]
+            actual_error = float(100) - float(error)
+            logger.debug(f"Match percentage: {actual_error}%")
+            if actual_error >= delta:
+                logger.trace("Matched image")
+                return True
+            else:
+                logger.trace("Images not similar")

--- a/MangaManager/src/MetadataManager/GUI/widgets/TreeviewWidget.py
+++ b/MangaManager/src/MetadataManager/GUI/widgets/TreeviewWidget.py
@@ -88,7 +88,7 @@ class TreeviewWidget(Treeview):
     def reset_loadedcinfo_changes(self, event=None):
         raise NotImplementedError()
 
-    def _run_hook(source: list[callable], *args):
+    def _run_hook(self, source: list[callable], *args):
         for hook_function in source:
             try:
                 hook_function(*args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ Pillow
 natsort>=8.2.0
 lxml >= 4.9.1
 six >= 1.16.0
-requests
-anytree
+requests~=2.28.2
+anytree~=2.8.0
+numpy~=1.24.2


### PR DESCRIPTION
This PR enables a new button in CoverManager that lets the user scan images similar to the selected one to easily apply actions to all images.

- [x] Let the user scan selected file
- [x] Let the user choose to only scan cover/backcover / both