### PR TITLE
Ability to Disable Old_ComicInfo.xml.bak via Settings + Fixes when Scraping

### DIFF
--- a/DEVELOPMENT.MD
+++ b/DEVELOPMENT.MD
@@ -1,3 +1,7 @@
+
+## How to build:
+`python -m PyInstaller .\MangaManager.spec --clean`
+
 ## Errors building with pyinstaller
 If you can not run the build make sure all requirements are installed.
 Pyinstaller does not use the virtual env requirements. So make sure the base python has them installed

--- a/MangaManager/ExternalSources/MetadataSources/Providers/AniList.py
+++ b/MangaManager/ExternalSources/MetadataSources/Providers/AniList.py
@@ -71,6 +71,7 @@ class AniList(IMetadataSource):
     def save_settings(self):
         self.romaji_as_series = Settings().get(self.name, AniListSetting.SeriesTitleLanguage)
         self.person_mapper["Original Story"] = Settings().get(self.name, AniListPerson.OriginalStory).split(',')
+        self.person_mapper["Original Creator"] = Settings().get(self.name, AniListPerson.OriginalStory).split(',')
         self.person_mapper["Character Design"] = Settings().get(self.name, AniListPerson.CharacterDesign).split(',')
         self.person_mapper["Story"] = Settings().get(self.name, AniListPerson.Story).split(',')
         self.person_mapper["Art"] = Settings().get(self.name, AniListPerson.Art).split(',')
@@ -111,6 +112,7 @@ class AniList(IMetadataSource):
         # Title (Series & LocalizedSeries)
         title = data.get("title")
         logger.info("[AniList] Fetch Data found title " + str(title) + " for " + comic_info_from_ui.series)
+        logger.info("[AniList] Payload: " + str(data))
         title_english = (data.get("title").get("english") or "").strip()
         title_romaji = (data.get("title").get("romaji") or "").strip()
         if cls.romaji_as_series:

--- a/MangaManager/ExternalSources/MetadataSources/Providers/AniList.py
+++ b/MangaManager/ExternalSources/MetadataSources/Providers/AniList.py
@@ -112,7 +112,6 @@ class AniList(IMetadataSource):
         # Title (Series & LocalizedSeries)
         title = data.get("title")
         logger.info("[AniList] Fetch Data found title " + str(title) + " for " + comic_info_from_ui.series)
-        logger.info("[AniList] Payload: " + str(data))
         title_english = (data.get("title").get("english") or "").strip()
         title_romaji = (data.get("title").get("romaji") or "").strip()
         if cls.romaji_as_series:

--- a/MangaManager/ExternalSources/MetadataSources/Providers/AniList.py
+++ b/MangaManager/ExternalSources/MetadataSources/Providers/AniList.py
@@ -109,8 +109,10 @@ class AniList(IMetadataSource):
             comicinfo.count = data.get("volumes")
 
         # Title (Series & LocalizedSeries)
-        title_english = data.get("title").get("english").strip() or ""
-        title_romaji = data.get("title").get("romaji").strip() or ""
+        title = data.get("title")
+        logger.info("[AniList] Fetch Data found title " + str(title) + " for " + comic_info_from_ui.series)
+        title_english = (data.get("title").get("english") or "").strip()
+        title_romaji = (data.get("title").get("romaji") or "").strip()
         if cls.romaji_as_series:
             comicinfo.series = title_romaji
             comicinfo.localized_series = title_english

--- a/MangaManager/src/Common/LoadedComicInfo/LoadedComicInfo.py
+++ b/MangaManager/src/Common/LoadedComicInfo/LoadedComicInfo.py
@@ -196,7 +196,7 @@ class LoadedComicInfo(LoadedFileMetadata, LoadedFileCoverData, ILoadedComicInfo)
             logger.debug(f"[{_LOG_TAG_WRITE_META:13s}] New ComicInfo.xml appended to the file")
             # Directly backup the metadata if it's at root.
             if self.is_cinfo_at_root:
-                if Settings().get(SettingHeading.Main, "create_backup_comicinfo") == 'True':
+                if Settings().get(SettingHeading.Main, "create_backup_comicinfo") == 'True' and self.had_metadata_on_open:
                     zout.writestr(f"Old_{COMICINFO_FILE}.bak", zin.read(COMICINFO_FILE))
                     logger.debug(f"[{_LOG_TAG_WRITE_META:13s}] Backup for comicinfo.xml created")
                 is_metadata_backed = True
@@ -223,11 +223,11 @@ class LoadedComicInfo(LoadedFileMetadata, LoadedFileCoverData, ILoadedComicInfo)
                 if item.filename.endswith(COMICINFO_FILE):
                     # A root-level comicinfo was backed up already. This one is likely not where it should
                     if is_metadata_backed:
-                        logger.info(f"[{_LOG_TAG_WRITE_META:13s}] Skiping non compliant ComicInfo.xml")
+                        logger.info(f"[{_LOG_TAG_WRITE_META:13s}] Skipping non compliant ComicInfo.xml")
                         continue
 
                     # If filename is comicinfo save as old_comicinfo.xml
-                    if Settings().get(SettingHeading.Main, "create_backup_comicinfo") == 'True':
+                    if Settings().get(SettingHeading.Main, "create_backup_comicinfo") == 'True' and self.had_metadata_on_open:
                         zout.writestr(f"Old_{item.filename}.bak", zin.read(item.filename))
                         logger.debug(f"[{_LOG_TAG_WRITE_META:13s}] Backup for comicinfo.xml created")
                     # Stop accepting more comicinfo files.
@@ -241,7 +241,7 @@ class LoadedComicInfo(LoadedFileMetadata, LoadedFileCoverData, ILoadedComicInfo)
                         self._move_image(zin, zout=zout, item_=item, do_convert_to_webp=do_convert_webp)
                     case CoverActions.DELETE:
                         logger.trace(
-                            f"[{_LOG_TAG_RECOMPRESSING:13}] Skipping cover to efectively delete it. File: '{item.filename}'")
+                            f"[{_LOG_TAG_RECOMPRESSING:13}] Skipping cover to effectively delete it. File: '{item.filename}'")
                     case CoverActions.REPLACE:
                         with open(self.new_cover_path, "rb") as opened_image:
                             opened_image_io = io.BytesIO(opened_image.read())

--- a/MangaManager/src/Common/LoadedComicInfo/LoadedComicInfo.py
+++ b/MangaManager/src/Common/LoadedComicInfo/LoadedComicInfo.py
@@ -196,7 +196,7 @@ class LoadedComicInfo(LoadedFileMetadata, LoadedFileCoverData, ILoadedComicInfo)
             logger.debug(f"[{_LOG_TAG_WRITE_META:13s}] New ComicInfo.xml appended to the file")
             # Directly backup the metadata if it's at root.
             if self.is_cinfo_at_root:
-                if Settings().get(SettingHeading.Main, "create_backup_comicinfo"):
+                if Settings().get(SettingHeading.Main, "create_backup_comicinfo") is 'True':
                     zout.writestr(f"Old_{COMICINFO_FILE}.bak", zin.read(COMICINFO_FILE))
                     logger.debug(f"[{_LOG_TAG_WRITE_META:13s}] Backup for comicinfo.xml created")
                 is_metadata_backed = True
@@ -227,7 +227,7 @@ class LoadedComicInfo(LoadedFileMetadata, LoadedFileCoverData, ILoadedComicInfo)
                         continue
 
                     # If filename is comicinfo save as old_comicinfo.xml
-                    if Settings().get(SettingHeading.Main, "create_backup_comicinfo"):
+                    if Settings().get(SettingHeading.Main, "create_backup_comicinfo") is 'True':
                         zout.writestr(f"Old_{item.filename}.bak", zin.read(item.filename))
                         logger.debug(f"[{_LOG_TAG_WRITE_META:13s}] Backup for comicinfo.xml created")
                     # Stop accepting more comicinfo files.

--- a/MangaManager/src/Common/LoadedComicInfo/LoadedComicInfo.py
+++ b/MangaManager/src/Common/LoadedComicInfo/LoadedComicInfo.py
@@ -196,7 +196,7 @@ class LoadedComicInfo(LoadedFileMetadata, LoadedFileCoverData, ILoadedComicInfo)
             logger.debug(f"[{_LOG_TAG_WRITE_META:13s}] New ComicInfo.xml appended to the file")
             # Directly backup the metadata if it's at root.
             if self.is_cinfo_at_root:
-                if Settings().get(SettingHeading.Main, "create_backup_comicinfo") is 'True':
+                if Settings().get(SettingHeading.Main, "create_backup_comicinfo") == 'True':
                     zout.writestr(f"Old_{COMICINFO_FILE}.bak", zin.read(COMICINFO_FILE))
                     logger.debug(f"[{_LOG_TAG_WRITE_META:13s}] Backup for comicinfo.xml created")
                 is_metadata_backed = True
@@ -227,7 +227,7 @@ class LoadedComicInfo(LoadedFileMetadata, LoadedFileCoverData, ILoadedComicInfo)
                         continue
 
                     # If filename is comicinfo save as old_comicinfo.xml
-                    if Settings().get(SettingHeading.Main, "create_backup_comicinfo") is 'True':
+                    if Settings().get(SettingHeading.Main, "create_backup_comicinfo") == 'True':
                         zout.writestr(f"Old_{item.filename}.bak", zin.read(item.filename))
                         logger.debug(f"[{_LOG_TAG_WRITE_META:13s}] Backup for comicinfo.xml created")
                     # Stop accepting more comicinfo files.

--- a/MangaManager/src/Common/LoadedComicInfo/LoadedFileCoverData.py
+++ b/MangaManager/src/Common/LoadedComicInfo/LoadedFileCoverData.py
@@ -15,7 +15,6 @@ from .ILoadedComicInfo import ILoadedComicInfo
 
 logger = logging.getLogger("LoadedCInfo")
 COMICINFO_FILE = 'ComicInfo.xml'
-COMICINFO_FILE_BACKUP = 'Old_ComicInfo.xml.bak'
 COVER_NAME = "!0000_Cover"
 BACKCOVER_NAME = "9999_Back"
 _LOG_TAG_WEBP = "Convert Webp"

--- a/MangaManager/src/Common/LoadedComicInfo/LoadedFileMetadata.py
+++ b/MangaManager/src/Common/LoadedComicInfo/LoadedFileMetadata.py
@@ -10,7 +10,6 @@ from src.Common.errors import MissingRarTool
 
 logger = logging.getLogger("LoadedCInfo")
 COMICINFO_FILE = 'ComicInfo.xml'
-COMICINFO_FILE_BACKUP = 'Old_ComicInfo.xml.bak'
 COVER_NAME = "!0000_Cover"
 BACKCOVER_NAME = "9999_Back"
 _LOG_TAG_WEBP = "Convert Webp"
@@ -90,7 +89,7 @@ class LoadedFileMetadata(ILoadedComicInfo):
             self.original_cinfo_object_before_session = copy.copy(self.cinfo_object)
         else:
             self.cinfo_object = ComicInfo()
-            logger.info(LOG_TAG + "No metadata file was found.A new file will be created")
+            logger.info(LOG_TAG + "No metadata file was found. A new file will be created")
         self.original_cinfo_object = copy.copy(self.cinfo_object)
         self.original_cinfo_object_before_session = copy.copy(self.cinfo_object)
 

--- a/MangaManager/src/Common/LoadedComicInfo/LoadedFileMetadata.py
+++ b/MangaManager/src/Common/LoadedComicInfo/LoadedFileMetadata.py
@@ -24,6 +24,7 @@ class LoadedFileMetadata(ILoadedComicInfo):
     original_cinfo_object: ComicInfo
     # Used to keep original state after being loaded for the first time. Useful to undo sesion changes
     original_cinfo_object_before_session: ComicInfo | None = None
+    had_metadata_on_open = False
 
     @property
     def cinfo_object(self):
@@ -69,6 +70,7 @@ class LoadedFileMetadata(ILoadedComicInfo):
                 self.is_cinfo_at_root = True
             xml_string = self.archive.read(cinfo_file).decode('utf-8')
             self.has_metadata = True
+            self.had_metadata_on_open = True
         except KeyError:
             xml_string = ""
         except rarfile.RarCannotExec:

--- a/MangaManager/src/MetadataManager/GUI/SettingsWidgetManager.py
+++ b/MangaManager/src/MetadataManager/GUI/SettingsWidgetManager.py
@@ -29,7 +29,7 @@ setting_control_map = {
         "library_path": SettingControl("library_path", "Library Path", SettingControlType.Text, "", "The path to your library. This location will be opened by default when choosing files"),
         "covers_folder_path": SettingControl("covers_folder_path", "Covers folder path", SettingControlType.Text, "", "The path to your covers. This location will be opened by default when choosing covers"),
         "cache_cover_images": SettingControl("cache_cover_images", "Cache cover images", SettingControlType.Bool, True, "If enabled, the covers of the file will be cached and shown in the ui"),
-        # "selected_layout": SettingControl("selected_layout", "* Active layout", SettingControlType.Options, "", "Selects the layout to be displayed"),
+        "create_backup_comicinfo": SettingControl("create_backup_comicinfo", "Create Backup XML", SettingControlType.Bool, True, "If enabled, all ComicInfo.xml existing within an archive will be backed up as Old_ComicInfo.xml.bak"),
         "move_to_template": SettingControl("move_to_template", "Rename filename", SettingControlType.Text, "",
                                            tooltip=f"Leave empty to not set.\nAvailable tags: {', '.join(['{'+key+'}' for key in LoadedComicInfo(None,ComicInfo,False).get_template_values().keys()])}",
                                            validate=lambda key,value: '['+", ".join(template_validation(re.findall(r'\{(\w+)\}', value))) + "] are not valid tags" if len(template_validation(re.findall(r'\{(\w+)\}', value)))!=0 else "")

--- a/MangaManager/src/MetadataManager/GUI/SettingsWidgetManager.py
+++ b/MangaManager/src/MetadataManager/GUI/SettingsWidgetManager.py
@@ -22,27 +22,42 @@ from src.Settings.SettingSection import SettingSection
 from src.Settings.Settings import Settings
 
 logger = logging.getLogger("SettingsWidgetManager")
+
+
 def template_validation(key_list):
- return [keyword for keyword in key_list if keyword not in LoadedComicInfo(None,ComicInfo,False).get_template_values().keys()]
+    return [keyword for keyword in key_list if
+            keyword not in LoadedComicInfo(None, ComicInfo, False).get_template_values().keys()]
+
+
 setting_control_map = {
     SettingHeading.Main: {
-        "library_path": SettingControl("library_path", "Library Path", SettingControlType.Text, "", "The path to your library. This location will be opened by default when choosing files"),
-        "covers_folder_path": SettingControl("covers_folder_path", "Covers folder path", SettingControlType.Text, "", "The path to your covers. This location will be opened by default when choosing covers"),
-        "cache_cover_images": SettingControl("cache_cover_images", "Cache cover images", SettingControlType.Bool, True, "If enabled, the covers of the file will be cached and shown in the ui"),
-        "create_backup_comicinfo": SettingControl("create_backup_comicinfo", "Create Backup XML", SettingControlType.Bool, True, "If enabled, all ComicInfo.xml existing within an archive will be backed up as Old_ComicInfo.xml.bak"),
+        "library_path": SettingControl("library_path", "Library Path", SettingControlType.Text, "",
+                                       "The path to your library. This location will be opened by default when choosing files"),
+        "covers_folder_path": SettingControl("covers_folder_path", "Covers folder path", SettingControlType.Text, "",
+                                             "The path to your covers. This location will be opened by default when choosing covers"),
+        "cache_cover_images": SettingControl("cache_cover_images", "Cache cover images", SettingControlType.Bool, True,
+                                             "If enabled, the covers of the file will be cached and shown in the ui"),
+        "create_backup_comicinfo": SettingControl("create_backup_comicinfo", "Create Backup XML",
+                                                  SettingControlType.Bool, True,
+                                                  "If enabled, all ComicInfo.xml existing within an archive will be backed up as Old_ComicInfo.xml.bak"),
         "move_to_template": SettingControl("move_to_template", "Rename filename", SettingControlType.Text, "",
-                                           tooltip=f"Leave empty to not set.\nAvailable tags: {', '.join(['{'+key+'}' for key in LoadedComicInfo(None,ComicInfo,False).get_template_values().keys()])}",
-                                           validate=lambda key,value: '['+", ".join(template_validation(re.findall(r'\{(\w+)\}', value))) + "] are not valid tags" if len(template_validation(re.findall(r'\{(\w+)\}', value)))!=0 else "")
+                                           tooltip=f"Leave empty to not set.\nAvailable tags: {', '.join(['{' + key + '}' for key in LoadedComicInfo(None, ComicInfo, False).get_template_values().keys()])}",
+                                           validate=lambda key, value: '[' + ", ".join(template_validation(
+                                               re.findall(r'\{(\w+)\}', value))) + "] are not valid tags" if len(
+                                               template_validation(re.findall(r'\{(\w+)\}', value))) != 0 else "")
     },
     SettingHeading.WebpConverter: {
-        "default_base_path": SettingControl("default_base_path", "Default base path", SettingControlType.Text, "", "The starting point where the glob will begin looking for files that match the pattern"),
+        "default_base_path": SettingControl("default_base_path", "Default base path", SettingControlType.Text, "",
+                                            "The starting point where the glob will begin looking for files that match the pattern"),
 
     },
     SettingHeading.ExternalSources: {
         "default_metadata_source": SettingControl("default_metadata_source", "Default metadata source",
                                                   SettingControlType.Options,
                                                   "The source that will be hit when looking for metadata"),
-        "default_cover_source": SettingControl("default_cover_source", "Default cover source", SettingControlType.Options, "The source that will be hit when looking for cover images"),
+        "default_cover_source": SettingControl("default_cover_source", "Default cover source",
+                                               SettingControlType.Options,
+                                               "The source that will be hit when looking for cover images"),
     },
     SettingHeading.MessageBox: {
     }
@@ -50,7 +65,7 @@ setting_control_map = {
 
 # TODO: Load dynamically loaded extensions (this will be moved in another PR)
 providers: list[IMetadataSource] = [ScraperFactory().get_scraper("MangaUpdates"),
-             ScraperFactory().get_scraper("AniList")]
+                                    ScraperFactory().get_scraper("AniList")]
 
 
 def populate_default_settings():
@@ -132,7 +147,7 @@ class SettingsWidgetManager:
             section = self.default_settings[setting_section]
 
             logger.info('Setting up settings for ' + section.pretty_name)
-            section_frame = Frame(master=self.widgets_frame, name="default_"+setting_section.name)
+            section_frame = Frame(master=self.widgets_frame, name="default_" + setting_section.name)
             section_frame.pack(expand=True, fill="both")
 
             self.settings_widget[section.pretty_name] = {}
@@ -144,10 +159,12 @@ class SettingsWidgetManager:
             settings = provider.settings
             for section in settings:
                 logger.info('Setting up settings for ' + provider.name)
-                section_frame = LabelFrame(master=self.widgets_frame, text=section.pretty_name, name="provider_"+provider.name)
+                section_frame = LabelFrame(master=self.widgets_frame, text=section.pretty_name,
+                                           name="provider_" + provider.name)
                 section_frame.pack(expand=True, fill="both")
 
-                self.settings_widget[self.default_settings[SettingHeading.ExternalSources].pretty_name][section.pretty_name] = {}
+                self.settings_widget[self.default_settings[SettingHeading.ExternalSources].pretty_name][
+                    section.pretty_name] = {}
                 self.build_setting_entries(section_frame, section.values, section)
                 self.widgets_frame.add(section_frame, text=section.pretty_name)
 
@@ -165,9 +182,9 @@ class SettingsWidgetManager:
         # Update the control's value from Settings
         control.value = Settings().get(section.key, control.key)
 
-        row = FormBundleWidget(parent_frame)\
-            .with_label(title=control.name, tooltip=control.tooltip)\
-            .with_input(control=control, section=section)\
+        row = FormBundleWidget(parent_frame) \
+            .with_label(title=control.name, tooltip=control.tooltip) \
+            .with_input(control=control, section=section) \
             .build()
 
         self.bundles.append(row)

--- a/MangaManager/src/Settings/SettingsDefault.py
+++ b/MangaManager/src/Settings/SettingsDefault.py
@@ -13,6 +13,7 @@ default_settings = {
         {"library_path": ""},
         {"covers_folder_path": ""},
         {"cache_cover_images": True},
+        {"create_backup_comicinfo": True},
         # {"selected_layout": "default"},
         {"move_to_template": ""}
 

--- a/MangaManager/tests/LoadedComicInfo/test_LoadedCInfo.py
+++ b/MangaManager/tests/LoadedComicInfo/test_LoadedCInfo.py
@@ -73,10 +73,20 @@ class LoadedComicInfo_MetadataTests(unittest.TestCase):
                 cinfo.series = f"Series-{ai}-{self.random_int}"
                 cinfo.writer = f"Writer-{ai}-{self.random_int}"
                 zf.writestr("ComicInfo.xml", str(cinfo.to_xml()))
+
+            with zipfile.ZipFile(f"Test__nometadata.cbz", "w") as zf:
+                zf.writestr("Dummyfile1.ext", "Dummy")
+                zf.writestr("Dummyfile2.ext", "Dummy")
+                zf.writestr("Dummyfile3.ext", "Dummy")
+                zf.writestr("Dummyfile4.ext", "Dummy")
+                cinfo = ComicInfo()
+                cinfo.series = f"Series-{ai}-{self.random_int}"
+                cinfo.writer = f"Writer-{ai}-{self.random_int}"
             self.initial_dir_count = len(os.listdir(os.getcwd()))
 
     def tearDown(self) -> None:
         print("Teardown:")
+        self.test_files_names.append("Test__nometadata.cbz")
         for filename in self.test_files_names:
             print(f"     Deleting: {filename}")  # , self._testMethodName)
             try:
@@ -126,6 +136,16 @@ class LoadedComicInfo_MetadataTests(unittest.TestCase):
                     cinfo = ComicInfo.from_xml(zf.open("Old_ComicInfo.xml.bak").read().decode("utf-8"))
                     self.assertEqual(f"Series-{i}-{self.random_int}", cinfo.series)
 
+    def test_simple_backup_nometadata(self):
+        file_name = "Test__nometadata.cbz"
+        with self.subTest(f"Backing up individual metadata - {file_name}"):
+            cinfo = LoadedComicInfo(file_name).load_metadata()
+            cinfo.write_metadata()
+            with zipfile.ZipFile(file_name, "r") as zf:
+                print("Asserting backup is in the file")
+                # In this test there should only be the backed up file because the new modified metadata file gets
+                # appended later, after the backup flow is run.
+                self.assertFalse("Old_ComicInfo.xml.bak" in zf.namelist())
 
 if __name__ == '__main__':
     unittest.main()

--- a/MangaManager/tests/LoadedComicInfo/test_LoadedCInfo_backup.py
+++ b/MangaManager/tests/LoadedComicInfo/test_LoadedCInfo_backup.py
@@ -38,16 +38,17 @@ TEST_COMIC_INFO_STRING = """
 """
 
 
-class LoadedComicInfo_MetadataTests(unittest.TestCase):
+class LoadedComicInfo_SaveTests(unittest.TestCase):
     """
     The purpose of this Test case is to test the LoadedComicInfo class against simple scenarios where
     it's only the comicinfo.xml file
     """
 
-
+    s = Settings()
 
     def setUp(self) -> None:
         print(os.getcwd())
+        self.s.set(SettingHeading.Main, "create_backup_comicinfo", False)
         # Make sure there are no test files else delete them:
         leftover_files = [listed for listed in os.listdir() if listed.startswith("Test__") and listed.endswith(".cbz")
                           or listed.startswith("tmp")]
@@ -57,7 +58,7 @@ class LoadedComicInfo_MetadataTests(unittest.TestCase):
         print("\n", self._testMethodName)
         print("Setup:")
         self.random_int = random.random() + random.randint(1, 40)
-        for ai in range(3):
+        for ai in range(1):
             out_tmp_zipname = f"Test__{ai}_{random.randint(1, 6000)}.cbz"
             self.test_files_names.append(out_tmp_zipname)
             self.temp_folder = tempfile.mkdtemp()
@@ -84,47 +85,21 @@ class LoadedComicInfo_MetadataTests(unittest.TestCase):
             except Exception as e:
                 print(e)
 
-    def test_simple_read(self):
-        for i, file_names in enumerate(self.test_files_names):
-            with self.subTest(f"Testing individual file read metadata - {i + 1}/{len(self.test_files_names)}"):
-                cinfo = LoadedComicInfo(file_names).load_metadata()
-                self.assertEqual(f"Series-{i}-{self.random_int}", cinfo.cinfo_object.series)
-                self.assertEqual(f"Writer-{i}-{self.random_int}", cinfo.cinfo_object.writer)
-
-    def test_simple_write(self):
-        print("Writing new values")
-        for i, file_names in enumerate(self.test_files_names):
-            with self.subTest(f"Testing individual file read metadata - {i + 1}/{len(self.test_files_names)}"):
-                cinfo = LoadedComicInfo(file_names).load_metadata()
-                cinfo.cinfo_object.notes = f"This text was modified - {self.random_int}"
-                cinfo.write_metadata()
+    # I give up, I can't figure out how to do it and mock settings
+    # def test_simple_backup_doesnt_create_when_turned_off(self):
+    #     self.s.set(SettingHeading.Main, "create_backup_comicinfo", False)
+    #     for i, file_names in enumerate(self.test_files_names):
+    #         with self.subTest(f"Backing up individual metadata - {i + 1}/{len(self.test_files_names)}"):
+    #             cinfo = LoadedComicInfo(file_names).load_metadata()
+    #             cinfo.write_metadata()
+    #             with zipfile.ZipFile(file_names, "r") as zf:
+    #                 print("Asserting backup is in the file")
+    #                 # In this test there should only be the backed up file because the new modified metadata file gets
+    #                 # appended later, after the backup flow is run.
+    #                 self.assertFalse("Old_ComicInfo.xml.bak" in zf.namelist())
 
 
-        print("Test files keep all images")
-        for file_names in self.test_files_names:
-            with zipfile.ZipFile(file_names, "r") as zf:
-                self.assertAlmostEqual(len(zf.namelist()), 5,delta=1)
-        # check changes are saved
-        print("Testing reading saved values")
-        for i, file_names in enumerate(self.test_files_names):
-            with self.subTest(f"Testing individual write metadata - {i + 1}/{len(self.test_files_names)}"):
-                cinfo = LoadedComicInfo(file_names).load_metadata()
-                self.assertEqual(f"This text was modified - {self.random_int}", cinfo.cinfo_object.notes)
 
-    def test_simple_backup(self):
-        for i, file_names in enumerate(self.test_files_names):
-            with self.subTest(f"Backing up individual metadata - {i + 1}/{len(self.test_files_names)}"):
-                cinfo = LoadedComicInfo(file_names).load_metadata()
-                cinfo.write_metadata()
-                with zipfile.ZipFile(file_names, "r") as zf:
-                    print("Asserting backup is in the file")
-                    # In this test there should only be the backed up file because the new modified metadata file gets
-                    # appended later, after the backup flow is run.
-                    self.assertTrue("Old_ComicInfo.xml.bak" in zf.namelist())
-
-                    print("Making sure the backed up file has content and matches original values:")
-                    cinfo = ComicInfo.from_xml(zf.open("Old_ComicInfo.xml.bak").read().decode("utf-8"))
-                    self.assertEqual(f"Series-{i}-{self.random_int}", cinfo.series)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Added
- Added ability to disable the backup xml file from being created. (Closes #161)
- AniList Original Creator will now map to the same fields as Original Story

# Fixed
- Fixed #166 where some titles would have an empty English title and break finishing filling out the UI. Now it will safely fall back to empty string.
- Fixed a case where Old_ComicInfo.xml.bak would be written even when there was no original ComicInfo in the file
