### PR TITLE
Fix issue #222

### DIFF
--- a/MangaManager/MangaManager/LoadedComicInfo/LoadedFileMetadata.py
+++ b/MangaManager/MangaManager/LoadedComicInfo/LoadedFileMetadata.py
@@ -63,8 +63,8 @@ class LoadedFileMetadata(ILoadedComicInfo):
         try:
             # If Comicinfo is not at root try to grab any ComicInfo.xml in the file
             if COMICINFO_FILE not in self.archive.namelist():
-                cinfo_file = [filename.endswith(COMICINFO_FILE) for filename in self.archive.namelist()][
-                                 0] or COMICINFO_FILE
+                cinfo_file = next((filename for filename in self.archive.namelist() 
+                                   if filename.endswith(COMICINFO_FILE))) or COMICINFO_FILE
             else:
                 cinfo_file = COMICINFO_FILE
                 self.is_cinfo_at_root = True


### PR DESCRIPTION
Resolves issue: #222 

**Changes Made**
Fix a bug where ComicInfo.xml could not be found when not at the archive root.  Changed the list comprehension to return the first occurrence of a filepath within the archive that ends with "ComicInfo.xml". 

**Original Technical Issue**
ComicInfo.xml could not be found when not at the archive root. This occurred because the index 0 of the list comprehension in the class **LoadedFileMetadata** would always return false and the fallback path within the archive (ComicInfo.xml) would be chosen instead. 

This occurred because the list comprehension was returning a list of boolean values generated by comparing filename.endswith("ComicInfo.xml"). Since index 0 of an archive.namelist() will always return a  folder or file at the root (and not a ComicInfo.xml since it's not at the root) , the value will always be false.